### PR TITLE
Fix typo QueueCauase -> QueueCause

### DIFF
--- a/src/main/java/org/jenkins/plugins/statistics/listeners/StatsQueueListener.java
+++ b/src/main/java/org/jenkins/plugins/statistics/listeners/StatsQueueListener.java
@@ -1,7 +1,7 @@
 package org.jenkins.plugins.statistics.listeners;
 
 import org.jenkins.plugins.statistics.model.StatsQueue;
-import org.jenkins.plugins.statistics.model.QueueCauase;
+import org.jenkins.plugins.statistics.model.QueueCause;
 import org.jenkins.plugins.statistics.util.*;
 import hudson.Extension;
 import hudson.model.Cause;
@@ -53,11 +53,11 @@ public class StatsQueueListener extends QueueListener {
 
   private void addEntryQueueCause(String name, Item wi,
                                   StatsQueue queue) {
-    QueueCauase cause = new QueueCauase();
+    QueueCause cause = new QueueCause();
     cause.setEntryTime(new Date());
     cause.setExitTime(null);
     cause.setReasonForWaiting(wi.getCauseOfBlockage().getShortDescription());
-    Map<String, QueueCauase> map = new HashMap<String, QueueCauase>();
+    Map<String, QueueCause> map = new HashMap<String, QueueCause>();
     map.put(name, cause);
     queue.setQueueCauses(map);
   }
@@ -83,11 +83,11 @@ public class StatsQueueListener extends QueueListener {
   }
 
   private void addExitQueueCause(String name, Item wi, StatsQueue queue) {
-    QueueCauase cause = new QueueCauase();
+    QueueCause cause = new QueueCause();
     cause.setEntryTime(null);
     cause.setExitTime(new Date());
     cause.setReasonForWaiting(wi.getCauseOfBlockage().getShortDescription());
-    Map<String, QueueCauase> map = new HashMap<String, QueueCauase>();
+    Map<String, QueueCause> map = new HashMap<String, QueueCause>();
     map.put(name, cause);
     queue.setQueueCauses(map);
   }

--- a/src/main/java/org/jenkins/plugins/statistics/model/QueueCause.java
+++ b/src/main/java/org/jenkins/plugins/statistics/model/QueueCause.java
@@ -5,7 +5,7 @@ import java.util.Date;
 /**
  * Created by hthakkallapally on 4/20/2015.
  */
-public class QueueCauase {
+public class QueueCause {
 
   private Date entryTime;
 

--- a/src/main/java/org/jenkins/plugins/statistics/model/StatsQueue.java
+++ b/src/main/java/org/jenkins/plugins/statistics/model/StatsQueue.java
@@ -26,7 +26,7 @@ public class StatsQueue {
 
   private String durationStr;
 
-  private Map<String, QueueCauase> queueCauses;
+  private Map<String, QueueCause> queueCauses;
 
   public String getCiUrl() {
     return ciUrl;
@@ -100,11 +100,11 @@ public class StatsQueue {
     this.durationStr = durationStr;
   }
 
-  public Map<String, QueueCauase> getQueueCauses() {
+  public Map<String, QueueCause> getQueueCauses() {
     return queueCauses;
   }
 
-  public void setQueueCauses(Map<String, QueueCauase> queueCauses) {
+  public void setQueueCauses(Map<String, QueueCause> queueCauses) {
     this.queueCauses = queueCauses;
   }
 }


### PR DESCRIPTION
Fixing typo in QueueCauase to QueueCause. Notice the extra a in the first one. 
